### PR TITLE
fix: install pandoc needed in workflow

### DIFF
--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Install pandoc
+        run: sudo apt-get install pandoc
+
       - name: Install pyfluent-parametric
         run: make install
 


### PR DESCRIPTION
The Nightly Documentation Build was failing because pandoc is not installed. This might be due to a change in the runners default packages. This should solve these issues (https://github.com/ansys/pyfluent-parametric/actions/runs/5724131562) and potentially #220